### PR TITLE
Reformat output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
-LOCAL.md
+# IDE files
+/.idea/
+
+# conf files
 *.json
 
+# binary files
 check_stackdriver
 check_stackdriver.exe
+check-stackdriver-go
+
+# misc
+LOCAL.md

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
I slightly adjusted the output format and performance data to display all entities that were checked.
Output example:
```
$ go run ./main.go -g 'project' -a 'config.json' -m 'agent.googleapis.com/memory/percent_used' -f 'metric.labels.state = "used"' -w 50 -c 70
CRITICAL: Project=project Zone=us-east4-a ID=1 [warn=50:crit=70:datapoints=73]
CRITICAL: Project=project Zone=us-west1-a ID=2 [warn=50:crit=70:datapoints=72]
CRITICAL: Project=project Zone=us-east4-b ID=3 [warn=50:crit=70:datapoints=73]
CRITICAL: Project=project Zone=us-west1-c ID=4 [warn=50:crit=70:datapoints=72]
WARNING: Project=project Zone=us-east4-b ID=5 [warn=50:crit=70:datapoints=69]
WARNING: Project=project Zone=us-west1-c ID=6 [warn=50:crit=70:datapoints=68]
OK: Project=project Zone=us-east4-c ID=7 [warn=50:crit=70:datapoints=25]
OK: Project=project Zone=us-west1-a ID=8 [warn=50:crit=70:datapoints=25]
OK: Project=project Zone=us-east4-a ID=9 [warn=50:crit=70:datapoints=25]
OK: Project=project Zone=us-west1-c ID=0 [warn=50:crit=70:datapoints=25]
|'1'=73.136428;50;70;0;0 '2'=72.728491;50;70;0;0 '3'=73.351873;50;70;0;0 '4'=72.721436;50;70;0;0 '5'=69.963329;50;70;0;0 '6'=68.364752;50;70;0;0 '7'=25.619119;50;70;0;0 '8'=25.989358;50;70;0;0 '9'=25.723772;50;70;0;0 '0'=25.624903;50;70;0;0 
```
This format allows to get more accurate information about the problem.